### PR TITLE
Fix/vue identicon attrs listeners

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -27,7 +27,7 @@
     "core-js": "^2.6.5",
     "file-saver": "^2.0.2",
     "serialize-javascript": "^2.1.1",
-    "vue": "2.6.10",
+    "vue": "2.6.11",
     "vue-class-component": "^7.2.2",
     "vue-clipboard2": "^0.3.1",
     "vue-property-decorator": "^8.4.0",
@@ -43,6 +43,6 @@
     "sass-loader": "^8.0.2",
     "tslint": "^6.1.0",
     "typescript": "^3.8.3",
-    "vue-template-compiler": "2.6.10"
+    "vue-template-compiler": "2.6.11"
   }
 }

--- a/dashboard/src/components/democracy/Proposal.vue
+++ b/dashboard/src/components/democracy/Proposal.vue
@@ -3,7 +3,9 @@
     <div class="card-content proposal-content">
       <div class="proposal-index" @click="toggleArgsVisible">{{ proposal.index.toString() }}</div>
       <div class="proposal-proposer">
-				<Identicon :value="proposal.proposer.toString()" />
+				<Identicon 
+          :value="proposal.proposer.toString()"
+          :size="size"/>
 				<div>
 				<div><b>Address: </b></div>
         <div>{{ address }}</div>
@@ -75,6 +77,8 @@ import shortAddress from '@/utils/shortAddress';
 })
 export default class Proposal extends Vue {
   @Prop() public proposal: any;
+  @Prop({ default: 64 }) public size!: number;
+
 
   private isArgsVisible: boolean = false;
 

--- a/dashboard/src/components/democracy/Proposal.vue
+++ b/dashboard/src/components/democracy/Proposal.vue
@@ -62,7 +62,7 @@ import { Component, Vue, Prop } from 'vue-property-decorator';
 import Argurments from '@/components/extrinsics/Arguments.vue';
 import Seconds from './Seconds.vue';
 import SecondModal from '@/components/shared/modals/Second.vue';
-import Identicon from '@polkadot/vue-identicon';
+import Identicon from '@vue-polkadot/vue-identicon';
 import shortAddress from '@/utils/shortAddress';
 
 @Component({

--- a/dashboard/src/components/shared/Backup.vue
+++ b/dashboard/src/components/shared/Backup.vue
@@ -3,6 +3,7 @@
     <b-field grouped multiline>
       <Identicon
         :value="address.toString()"
+        :size="size"
       />
       {{shortAddress(address)}}
       <b-button
@@ -46,6 +47,8 @@ import FileSaver from 'file-saver';
 export default class Backup extends Vue {
   @Prop(String) public address!: string;
   @Prop(String) public theme!: string;
+  @Prop({ default: 64 }) public size!: number;
+
 
   public password: string = '';
   public isPassValid: boolean = false;

--- a/dashboard/src/components/shared/Backup.vue
+++ b/dashboard/src/components/shared/Backup.vue
@@ -33,7 +33,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import Identicon from '@polkadot/vue-identicon';
+import Identicon from '@vue-polkadot/vue-identicon';
 import keyring from '@vue-polkadot/vue-keyring';
 import FileSaver from 'file-saver';
 

--- a/dashboard/src/components/shared/ChangePassword.vue
+++ b/dashboard/src/components/shared/ChangePassword.vue
@@ -2,6 +2,7 @@
   <div class="changepass">
     <Identicon
       :value="address.toString()"
+      :size="size"
       />
     {{shortAddress(address)}} 
     <b-field label="your current password" v-bind:type="{ 'is-danger': !isPassValid }">

--- a/dashboard/src/components/shared/ChangePassword.vue
+++ b/dashboard/src/components/shared/ChangePassword.vue
@@ -29,7 +29,7 @@
 </template>
 <script lang="ts">
 import { Vue, Component, Prop, Emit } from 'vue-property-decorator';
-import Identicon from '@polkadot/vue-identicon';
+import Identicon from '@vue-polkadot/vue-identicon';
 import keyring from '@vue-polkadot/vue-keyring';
 
 @Component({

--- a/dashboard/src/components/shared/Create.vue
+++ b/dashboard/src/components/shared/Create.vue
@@ -6,6 +6,7 @@
           <b-field>
             <Identicon 
               :value="newAccount.address.toString()"
+              :size="size"
              />
           </b-field>
           <b-field>
@@ -132,6 +133,8 @@ import { isHex, u8aToHex } from '@polkadot/util';
 export default class Create extends Vue {
   @Prop(String) public theme!: string;
   @Prop(String) public mode!: string;
+  @Prop({ default: 64 }) public size!: number;
+
   // will be replaced by uiSettings
   public keypairType: any = {
     selected: 'sr25519',

--- a/dashboard/src/components/shared/Create.vue
+++ b/dashboard/src/components/shared/Create.vue
@@ -119,7 +119,7 @@
 <script lang="ts">
 import { Component, Prop, Vue, Emit, Watch } from 'vue-property-decorator';
 import keyring from '@vue-polkadot/vue-keyring';
-import Identicon from '@polkadot/vue-identicon';
+import Identicon from '@vue-polkadot/vue-identicon';
 import { keyExtractSuri, mnemonicGenerate,
   mnemonicValidate, randomAsU8a } from '@polkadot/util-crypto';
 import { isHex, u8aToHex } from '@polkadot/util';

--- a/dashboard/src/components/shared/Keypair.vue
+++ b/dashboard/src/components/shared/Keypair.vue
@@ -97,7 +97,7 @@
 
 <script lang="ts">
 import { Component, Prop, Vue, Emit } from 'vue-property-decorator';
-import Identicon from '@polkadot/vue-identicon';
+import Identicon from '@vue-polkadot/vue-identicon';
 import keyring from '@vue-polkadot/vue-keyring';
 import Connector from '@vue-polkadot/vue-api';
 import formatBalance from '../../utils/formatBalance';

--- a/dashboard/src/components/transfer/TxSelect.vue
+++ b/dashboard/src/components/transfer/TxSelect.vue
@@ -5,7 +5,7 @@
           <Identicon
             :value="address"
             :theme="theme"
-            :size="56" />
+            :size="size" />
         </p>
         <b-field :label="label">
           <b-select :placeholder="placeholder" v-model="pickedAddress">
@@ -33,7 +33,7 @@
   <Identicon
     :value="address"
     :theme="theme"
-    :size="56" />
+    :size="size" />
   </p>
   <b-dropdown v-model="pickedAddress" aria-role="list">
         <button class="button is-large is-light" slot="trigger"> 
@@ -98,6 +98,8 @@ export default class TxPicker extends Vue {
   @Prop(String) public direction!: string;
   @Prop() public keyringAccounts!: any;
   @Prop() public balance!: any;
+  @Prop({ default: 56 }) public size!: number;
+
   @PropSync('address', { type: String }) public pickedAddress!: string;
   private pickedMetaName: string = '';
   public shortAddress(address: string): string {


### PR DESCRIPTION
Fixes vue-polkadot/vue-ui#23

Bumped the vue version and vue-template-compiler. 

Explanation of the fix: 
# Reproduce issue

Replace this line everywhere 
`import Identicon from '@polkadot/vue-identicon';`

with this line : 
`import Identicon from '@vue-polkadot/vue-identicon';`

This will then use Identicon from vue-polkadot and show the issue when you head to accounts/create

### Identify the issue
The issue was not anything to do with vue-identicon but in how it is being used in `vue-polkadot/apps`
In `vue-polkadot/apps` vue is pinned to version `2.6.10` but in the vue-identicon it is given an upwards pin of `^2.6.10`
This resulted in 2 defined versions of vue being installed and the cause of the issue.

### Verify the cause of the issue.
Before attempting a fix, replace `'@polkadot/vue-identicon';` with `'@vue-polkadot/vue-identicon'` as explained, install deps and serve. Then run `yarn why vue` and you will see it is being loaded with different versions in different places

### Suggested fixes
I see two fixes here. 
1. Update vue to 2.6.11 in `vue-polkadot/apps`
2. Update the vue dep in vue-polkdadot/apps to `^2.6.10` this will prevent double loading different versions of vue when using identicon in `vue-polkadot/apps`

I would recommend option 2 to prevent the issue creeping up again.  