### PR TITLE
add metadata tab in settings

### DIFF
--- a/dashboard/src/components/metadata/Metadata.vue
+++ b/dashboard/src/components/metadata/Metadata.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <DisabledInput
+      label="Address Prefix" :value="loading ? '' : chainProperties.ss58Format.toString()" />
+    <DisabledInput
+      label="Decimals" :value="loading ? '' : chainProperties.tokenDecimals.toString()" />
+    <DisabledInput
+      label="Unit" :value="loading ? '' : chainProperties.tokenSymbol.toString()" />
+     <DisabledInput 
+      label="Genesis Hash" :value="loading ? '' : chainProperties.genesisHash.toString()" /> 
+      <b-progress v-if="loading"
+      size="is-large" type="is-primary" show-value>Connecting</b-progress>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue, Watch, Emit } from 'vue-property-decorator';
+import DisabledInput from '@/components/shared/DisabledInput.vue';
+
+@Component({
+  components: {
+    DisabledInput
+  },
+})
+export default class Summary extends Vue {
+  private readonly emptyChainProperties: any =  {
+        ss58Format: '',  
+        tokenDecimals: '', 
+        genesisHash: '', 
+        tokenSymbol:''
+    }
+  public chainProperties: any = this.emptyChainProperties;
+  public loading: boolean = false;
+
+  @Watch('$store.state.chainProperties')
+  public mapProp(): void {  
+    this.chainProperties = {...this.emptyChainProperties, ...this.$store.state.chainProperties};
+  }
+
+  @Watch('$store.state.loading')
+  public mapLoading(): void {  
+    this.loading = this.$store.state.loading
+  }
+
+  public async mounted() {
+    this.mapProp();
+  }
+
+
+}
+</script>

--- a/dashboard/src/components/settings/General.vue
+++ b/dashboard/src/components/settings/General.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <SettingChooser label="Node URL" selector="availableNodes" setter="setApiUrl" defaultValue="apiUrl" addOption="local" addMethod="addNode" />
+    <SettingChooser label="Address Prefix" selector="availablePrefixes" setter="setPrefix" defaultValue="prefix"  />
+    <SettingChooser label="Default Icon Theme" selector="availableIcons" setter="setIcon"  defaultValue="icon" />
+    <SettingChooser label="Interface Operation Mode" selector="availableUiModes" setter="setUiMode"  defaultValue="uiMode" />
+    <!-- <SettingChooser label="Interface Operation Mode" selector="availableLocking" setter="setLocking"  defaultValue="locking" /> -->
+    <SettingChooserExplorer label="Default Explorer Provider" selector="provider" setter="setExplorer" defaultValue="0" />
+    <SettingChooserExplorer label="Default Explorer Chain" selector="chain" setter="setExplorer" defaultValue="0" />
+    
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import SettingChooser from '../settings/SettingChooser.vue';
+import SettingChooserExplorer from '@/components/settings/SettingChooserExplorer.vue'
+
+@Component({
+  components: {
+    SettingChooser,
+    SettingChooserExplorer,
+  },
+})
+export default class General extends Vue {
+
+}
+</script>

--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -18,14 +18,16 @@ const apiPlugin = (store: any) => {
   const { getInstance: Api } = Connector
   Api().on('connect', async (api: any) => {
     const { chainSS58, chainDecimals, chainToken  } = api.registry
+    const {genesisHash} = api
     console.log('[API] Connect to <3', store.state.setting.apiUrl, 
-      { chainSS58, chainDecimals, chainToken});
+      { chainSS58, chainDecimals, chainToken, genesisHash});
     store.commit('setChainProperties', {
       ss58Format: chainSS58 || 42,
       tokenDecimals: chainDecimals || 12,
-      tokenSymbol: chainToken || 'Unit'
+      tokenSymbol: chainToken || 'Unit',
+      genesisHash: genesisHash || ''
     })
-    
+    store.commit('setLoading', false)
   })
   Api().on('error', async (error: Error) => {
     store.commit('setError', error);

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -1,28 +1,33 @@
 <template>
   <div>
-     <b-tabs>
-        <b-tab-item label="General"></b-tab-item>
+       <b-tabs v-model="activeTab">
+      <b-tab-item label="General">
+        <General />
+      </b-tab-item>
+      <b-tab-item label="Metadata">
+        <Metadata />
+      </b-tab-item>
     </b-tabs>
-    <SettingChooser label="Node URL" selector="availableNodes" setter="setApiUrl" defaultValue="apiUrl" addOption="local" addMethod="addNode" />
-    <SettingChooser label="Address Prefix" selector="availablePrefixes" setter="setPrefix" defaultValue="prefix"  />
-    <SettingChooser label="Default Icon Theme" selector="availableIcons" setter="setIcon"  defaultValue="icon" />
-    <SettingChooser label="Interface Operation Mode" selector="availableUiModes" setter="setUiMode"  defaultValue="uiMode" />
-    <!-- <SettingChooser label="Interface Operation Mode" selector="availableLocking" setter="setLocking"  defaultValue="locking" /> -->
-    <SettingChooserExplorer label="Default Explorer Provider" selector="provider" setter="setExplorer" defaultValue="0" />
-    <SettingChooserExplorer label="Default Explorer Chain" selector="chain" setter="setExplorer" defaultValue="0" />
+
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import SettingChooser from '../components/settings/SettingChooser.vue';
-import SettingChooserExplorer from '@/components/settings/SettingChooserExplorer.vue'
+import General from '@/components/settings/General.vue';
+import Metadata from '@/components/metadata/Metadata.vue';
+
 
 @Component({
   components: {
-    SettingChooser,
-    SettingChooserExplorer,
+    General,
+    Metadata
   },
 })
-export default class Settings extends Vue {}
+export default class Settings extends Vue {
+  private activeTab: number = 0;
+
+
+}
 </script>
+


### PR DESCRIPTION
It adds the metadata tab in settings.
Regarding the detection of the right explorer in subscan, I think it's because of an inconsistency between the setting options (see picture).
<img width="536" alt="settings" src="https://user-images.githubusercontent.com/67239493/89609928-9b6f4c80-d84f-11ea-8266-b05bada46981.png">
