### PR TITLE
fix explorer links

### DIFF
--- a/dashboard/src/store.ts
+++ b/dashboard/src/store.ts
@@ -25,7 +25,10 @@ const apiPlugin = (store: any) => {
       tokenDecimals: chainDecimals || 12,
       tokenSymbol: chainToken || 'Unit'
     })
-    
+    const nodeInfo = store.getters.availableNodes
+        .filter((o:any) => o.value === store.state.setting.apiUrl)
+        .map((o:any) => {return o.info})[0]
+    store.commit('setExplorer', { 'chain': nodeInfo })
   })
   Api().on('error', async (error: Error) => {
     store.commit('setError', error);

--- a/dashboard/src/views/Settings.vue
+++ b/dashboard/src/views/Settings.vue
@@ -9,7 +9,6 @@
     <SettingChooser label="Interface Operation Mode" selector="availableUiModes" setter="setUiMode"  defaultValue="uiMode" />
     <!-- <SettingChooser label="Interface Operation Mode" selector="availableLocking" setter="setLocking"  defaultValue="locking" /> -->
     <SettingChooserExplorer label="Default Explorer Provider" selector="provider" setter="setExplorer" defaultValue="0" />
-    <SettingChooserExplorer label="Default Explorer Chain" selector="chain" setter="setExplorer" defaultValue="0" />
   </div>
 </template>
 


### PR DESCRIPTION
A possible solution to fix the explorer links, it uses the field 'info' from 'availableNodes' form the api and removes the field "default explorer chain" from the UI.