### PR TITLE
Update workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,17 @@ Basic usage is to interact from browser with Polkadot and Substrate based networ
 
 ```shell
 git clone git@github.com:vue-polkadot/apps.git
-cd dashboard;yarn
+cd dashboard
+yarn
 yarn serve
-open http://localhost:8080/
 ```
 
+Now, access apps in your browser at [http://127.0.0.1:9090/](http://127.0.0.1:9090/). You can also open the URL in your browser from another terminal session like this.
+
+```shell
+open http://localhost:9090/
+```
+ 
 ## 🏦 Stage One
 * [Accounts](https://kodadot.netlify.app/#/accounts) - It offers basic management functionality to work with Accounts
 * [Address book](https://kodadot.netlify.app/#/addressbook) - It offers basic management functionality to work with Addresses


### PR DESCRIPTION
This makes each CLI step under the play section a separate action (kinder to shell newcomers & easier to understand).

It also updates the URL opening step and moves the `open` command reference with a note that it must be run in a _new terminal session_, since it is not possible to do so from the same terminal session that `yarn serve` is run as a foreground process from.

Keep up the great work. It is all running nicely here locally for me.

Hope this helps!
